### PR TITLE
Experiment/figure6

### DIFF
--- a/data_loaders/GQA_sampler.py
+++ b/data_loaders/GQA_sampler.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
     # NOTE: way more local groups than global groups... so we'll use global groups
     #       due to chatgpt limitations... even the global groups are probably too much
     """
-    To evaluate on a diverse set of question types (~100 detailed types),
+    From visprog: "To evaluate on a diverse set of question types (~100 detailed types),
     we randomly sample up to k samples per question type from the balanced val
     (k = 5) and test-dev (k = 20) sets."
     """


### PR DESCRIPTION
"To evaluate on a diverse set of question types (~100 detailed types), we randomly sample up to k samples per question type from the balanced bal (k = 5) and test-dev (k = 20) sets."

GQA sampling according to the visprog paper. Likely way too many samples, and we will need to cut it down for each, but we will be able to do so quickly. I've added example usage in the if __name__ == "__main__" portion of the loader/sampler. 